### PR TITLE
Expand the ERT_RUNNER_OUTFILE file name.

### DIFF
--- a/ert-runner.el
+++ b/ert-runner.el
@@ -47,7 +47,8 @@
 (defvar ert-runner-test-path (f-expand "test")
   "Path to test dir.")
 
-(defconst ert-runner-output-file (getenv "ERT_RUNNER_OUTFILE")
+(defconst ert-runner-output-file (-when-let (env (getenv "ERT_RUNNER_OUTFILE"))
+                                   (f-expand env))
   "Path to outfile used for writing when non script mode.")
 
 (defun ert-runner-print (string)


### PR DESCRIPTION
When specifying a relative path, it was possible for ert-runner to write
output to different files, depending on the default-directory of
individual tests. This ensures that the output file is an absolute
file name.
