### PR TITLE
`ert-runner/run` improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ Run specific tests:
 
     $ cask exec ert-runner test/foo-test.el test/bar-test.el
 
-Same as above:
-
-    $ cask exec ert-runner foo-test.el bar-test.el
-
 Run test whose name matches a pattern:
 
     $ cask exec ert-runner -p pattern
@@ -59,7 +55,7 @@ Run all tests, whose name matches `request`, and which are tagged `fast` or
 `important`, but *not* `network`:
 
     $ cask exec ert-runner -p request -t fast,important -t !network
-    
+
 Run in "no win" mode:
 
     $ cask exec ert-runner --no-win

--- a/ert-runner.el
+++ b/ert-runner.el
@@ -174,7 +174,7 @@ primarily intended for reporters."
            (if paths
                (--any? (s-ends-with? it file) paths)
              (s-matches? "-test\.el$" file)))))
-    (f-files (f-expand ert-runner-test-path) el-tests-fn)))
+    (f-files (f-expand ert-runner-test-path) el-tests-fn t)))
 
 (defun ert-runner/run (&rest tests)
   (unless (f-dir? ert-runner-test-path)

--- a/ert-runner.el
+++ b/ert-runner.el
@@ -167,24 +167,30 @@ primarily intended for reporters."
       (setq file (f-expand file)))
   (load file nil :nomessage))
 
+(defun ert-runner--expand-test-path (path)
+  "Build expanded list of test files from PATH.
+Paths to files will simply be expanded, whereas paths to
+directories will be recursively checked for \"*-test.el\" files.
+An error will be signaled if a named file does not exist."
+  (setq path (f-expand path))
+  (unless (f-exists? path)
+    (error (ansi-red (format "`%s` does not exist." path))))
+  (if (f-dir? path)
+      (f-files path
+               (lambda (file)
+                 (s-matches? "-test\.el$" file))
+               t)
+    path))
+
 (defun ert-runner--test-files (paths)
-  "Return list of test files to run."
+  "Expand PATHS into a list of test files to run.
+See `ert-runner--expand-test-path' for details.  If PATHS is
+nil, `ert-runner-test-path' will be used instead."
   (unless paths
     (if (f-dir? ert-runner-test-path)
         (setq paths (list ert-runner-test-path))
       (error (ansi-red "No test directory. Create one using `ert-runner init`."))))
-  (-flatten
-   (mapcar (lambda (p)
-             (let ((path (f-expand p)))
-               (unless (f-exists? path)
-                 (error (ansi-red (format "`%s` does not exist." path))))
-               (if (f-dir? path)
-                   (f-files path
-                            (lambda (file)
-                              (s-matches? "-test\.el$" file))
-                            t)
-                 path)))
-           paths)))
+  (-flatten (mapcar #'ert-runner--expand-test-path paths)))
 
 (defun ert-runner/run (&rest tests)
   (ert-runner/use-reporter ert-runner-reporter-name)

--- a/features/ert-runner.feature
+++ b/features/ert-runner.feature
@@ -8,7 +8,7 @@ Feature: Ert Runner
       (ert-deftest bar-test ())
       (ert-deftest baz-test ())
       """
-    When I run cask exec "{ERT-RUNNER} foo-test.el --pattern foo"
+    When I run cask exec "{ERT-RUNNER} test/foo-test.el --pattern foo"
     Then I should see output:
       """
          passed  1/2  foo-test
@@ -25,7 +25,7 @@ Feature: Ert Runner
       (ert-deftest but-not-this ())
       (ert-deftest and-not-this ())
       """
-    When I run cask exec "{ERT-RUNNER} foo-test.el --tags foo,bar"
+    When I run cask exec "{ERT-RUNNER} test/foo-test.el --tags foo,bar"
     Then I should see test output:
       | name          | success |
       | this-test     | t       |
@@ -40,7 +40,7 @@ Feature: Ert Runner
       (ert-deftest but-this-one ())
       (ert-deftest and-this-one-too ())
       """
-    When I run cask exec "{ERT-RUNNER} foo-test.el --tags !foo"
+    When I run cask exec "{ERT-RUNNER} test/foo-test.el --tags !foo"
     Then I should see test output:
       | name              | success |
       | this-test         | t       |
@@ -56,7 +56,7 @@ Feature: Ert Runner
       (ert-deftest and-not-this-test () :tags '(foo))
       (ert-deftest and-not-this-one () :tags '(bar foo))
       """
-    When I run cask exec "{ERT-RUNNER} foo-test.el --tags !foo --tags bar"
+    When I run cask exec "{ERT-RUNNER} test/foo-test.el --tags !foo --tags bar"
     Then I should see output:
       """
          passed  1/1  this-test
@@ -71,7 +71,7 @@ Feature: Ert Runner
       (ert-deftest and-not-this-test () :tags '(foo))
       (ert-deftest and-not-this-one () :tags '(bar))
       """
-    When I run cask exec "{ERT-RUNNER} foo-test.el --tags bar --pattern test"
+    When I run cask exec "{ERT-RUNNER} test/foo-test.el --tags bar --pattern test"
     Then I should see output:
       """
          passed  1/1  this-test
@@ -87,7 +87,7 @@ Feature: Ert Runner
       """
       (ert-deftest foo () (foo))
       """
-    When I run cask exec "{ERT-RUNNER} foo-test.el"
+    When I run cask exec "{ERT-RUNNER} test/foo-test.el"
     Then I should not see error "(void-function foo)"
 
   Scenario: Only run specified files
@@ -99,7 +99,7 @@ Feature: Ert Runner
       """
       (ert-deftest bar-test () (error "BOOM"))
       """
-    When I run cask exec "{ERT-RUNNER} foo-test.el"
+    When I run cask exec "{ERT-RUNNER} test/foo-test.el"
     Then I should not see error "BOOM"
 
   Scenario: Run multiple files
@@ -111,7 +111,7 @@ Feature: Ert Runner
       """
       (ert-deftest bar-test ())
       """
-    When I run cask exec "{ERT-RUNNER} foo-test.el bar-test.el"
+    When I run cask exec "{ERT-RUNNER} test/foo-test.el test/bar-test.el"
     Then I should see output:
       """
          passed  1/2  bar-test

--- a/features/ert-runner.feature
+++ b/features/ert-runner.feature
@@ -91,7 +91,7 @@ Feature: Ert Runner
     Then I should not see error "(void-function foo)"
 
   Scenario: Only run specified files
-    When I create a test file called "foo-test.el" with content:
+    When I create a test file called "foo.el" with content:
       """
       (ert-deftest foo-test ())
       """
@@ -99,7 +99,7 @@ Feature: Ert Runner
       """
       (ert-deftest bar-test () (error "BOOM"))
       """
-    When I run cask exec "{ERT-RUNNER} test/foo-test.el"
+    When I run cask exec "{ERT-RUNNER} test/foo.el"
     Then I should not see error "BOOM"
 
   Scenario: Run multiple files
@@ -117,6 +117,27 @@ Feature: Ert Runner
          passed  1/2  bar-test
          passed  2/2  foo-test
       """
+
+  Scenario: Nested test directories
+    When I create a test file called "foo-test.el" with content:
+      """
+      (ert-deftest foo-test ())
+      """
+    When I create a test directory called "subdir"
+    When I create a test file called "subdir/bar-test.el" with content:
+      """
+      (ert-deftest bar-test ())
+      """
+    When I run cask exec "{ERT-RUNNER}"
+    Then I should see output:
+      """
+         passed  1/2  bar-test
+         passed  2/2  foo-test
+      """
+
+  Scenario: Nonexistent files
+    When I run cask exec "{ERT-RUNNER} test/missing-test.el"
+    Then I should see error "/missing-test.el` does not exist"
 
   Scenario: Run all files ending with -test.el automatically
     When I create a test file called "foo.el" with content:

--- a/features/step-definitions/ert-runner-steps.el
+++ b/features/step-definitions/ert-runner-steps.el
@@ -2,6 +2,10 @@
   (lambda (file content)
     (f-write-text content 'utf-8 (f-expand file ert-runner-project-test-path))))
 
+(When "^I create a test directory called \"\\([^\"]+\\)\"$"
+  (lambda (directory)
+    (f-mkdir (f-expand directory ert-runner-project-test-path))))
+
 (When "^I run cask exec \"\\([^\"]+\\)\"$"
   (lambda (command)
     (setq command (s-replace "{ERT-RUNNER}" ert-runner-bin-path command))

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -34,4 +34,5 @@
    (princ (ansi-red "%s" ert-runner-error))))
 
 (Before
- (mapc 'f-delete (f-glob "*.el" ert-runner-project-test-path)))
+ (mapc 'f-delete
+       (f--entries ert-runner-project-test-path (s-matches? ".el$" it) t)))


### PR DESCRIPTION
I ran across a couple behaviors today that surprised me and I decided to "fix" them. Hopefully you'll agree that this is an improvement. ;) Viz.:

1. Only test files in the top level of the `test` directory are run. This clashes with the common testing convention of mirroring the source tree structure in the test directory. Patch causes the `test` directory to be recursively listed for tests.
2. When directly calling, say, `cask exec ert-runner` with a list of file paths, these files are silently ignored if they aren't in the `test` directory or if they don't end with `-test.el`. Patch changes the behavior so that every file explicitly-named is evaluated (regardless of name or location). Directories are recursively listed and `*-test.el` files are evaluated.