### PR TITLE
Prepend instead of append when adding files to the load-path

### DIFF
--- a/ert-runner.el
+++ b/ert-runner.el
@@ -156,7 +156,7 @@ primarily intended for reporters."
 
 (defun ert-runner/load-path (path)
   "Append PATH to `load-path'."
-  (add-to-list 'load-path path nil))
+  (add-to-list 'load-path path))
 
 (defun ert-runner/usage ()
   "Show usage information."

--- a/ert-runner.el
+++ b/ert-runner.el
@@ -156,7 +156,7 @@ primarily intended for reporters."
 
 (defun ert-runner/load-path (path)
   "Append PATH to `load-path'."
-  (add-to-list 'load-path path 'append))
+  (add-to-list 'load-path path nil))
 
 (defun ert-runner/usage ()
   "Show usage information."


### PR DESCRIPTION
This makes it possible to use a different version of a package than the one provided by your emacs distribution
fixes #17