### PR TITLE
Add xfail to dot reporter

### DIFF
--- a/features/reporter.feature
+++ b/features/reporter.feature
@@ -93,3 +93,39 @@ Feature: Test Reporter
       1 unexpected results:
          FAILED  foo-test
       """
+
+  Scenario: Dot reporter expected fail failed
+    When I create a test file called "foo-test.el" with content:
+      """
+      (ert-deftest xfail-failed () :expected-result :failed (should nil))
+      """
+    And I run cask exec "{ERT-RUNNER} --reporter dot"
+    Then I should see output:
+      """
+      f
+
+      Ran 1 test in 0
+      """
+    And I should see output:
+      """
+      1 expected failures
+      """
+
+  Scenario: Dot reporter expected fail passed
+    When I create a test file called "foo-test.el" with content:
+      """
+      (ert-deftest xfail-passed () :expected-result :failed (should t))
+      """
+    And I run cask exec "{ERT-RUNNER} --reporter dot"
+    Then I should see error:
+      """
+      Test xfail-passed passed unexpectedly
+      P
+
+      Ran 1 test in 0
+      """
+    And I should see error:
+      """
+      1 unexpected results:
+         PASSED  xfail-passed
+      """

--- a/reporters/ert-runner-reporter-dot.el
+++ b/reporters/ert-runner-reporter-dot.el
@@ -48,7 +48,7 @@
                                   (if (= (ert-stats-total stats) 1)
                                       ""
                                     "s")
-                                  (time-to-seconds
+                                  (float-time
                                    (time-subtract (current-time)
                                                   ert-runner-reporter-dot-start-time))
                                   (if (zerop expected-failures)

--- a/reporters/ert-runner-reporter-dot.el
+++ b/reporters/ert-runner-reporter-dot.el
@@ -66,9 +66,11 @@
 
 (add-hook 'ert-runner-reporter-test-ended-functions
           (lambda (stats test result)
-            (if (ert-test-result-expected-p test result)
-                (ert-runner-message ".")
-              (ert-runner-message "F"))))
+            (let ((expectedp (ert-test-result-expected-p test result)))
+              (ert-runner-message
+               (char-to-string
+                (ert-char-for-test-result result expectedp))))))
+
 
 (provide 'ert-runner-reporter-dot)
 ;;; ert-runnert-reporter-dot.el ends here


### PR DESCRIPTION
This adds expected failures drawn as `x` and unexpected successes drawn as `X` in dot reporter.