### PR TITLE
Change -l/--load to accept single file arguments

### DIFF
--- a/ert-runner.el
+++ b/ert-runner.el
@@ -150,9 +150,9 @@ primarily intended for reporters."
   "Run tests matching PATTERN."
   (ert-runner/add-selector pattern))
 
-(defun ert-runner/load (&rest load-files)
+(defun ert-runner/load (load-files)
   "Load LOAD-FILES."
-  (setq ert-runner-load-files load-files))
+  (setq ert-runner-load-files (list load-files)))
 
 (defun ert-runner/load-path (path)
   "Append PATH to `load-path'."
@@ -330,7 +330,7 @@ nil, `ert-runner-test-path' will be used instead."
  (option "--help, -h" ert-runner/usage)
  (option "--pattern <pattern>, -p <pattern>" ert-runner/pattern)
  (option "--tags <tags>, -t <tags>" ert-runner/tags)
- (option "--load <*>, -l <*>" ert-runner/load)
+ (option "--load <file>, -l <file>" ert-runner/load)
  (option "--debug" ert-runner/debug)
  (option "--quiet" ert-runner/quiet)
  (option "--verbose" ert-runner/verbose)

--- a/features/ert-runner.feature
+++ b/features/ert-runner.feature
@@ -159,7 +159,7 @@ Feature: Ert Runner
          passed  2/2  foo-test
       """
 
-  Scenario: Load files
+  Scenario: Load file
     When I create a test file called "foo-init.el" with content:
       """
       (defun foo ())
@@ -173,6 +173,26 @@ Feature: Ert Runner
       """
          passed  1/1  foo-test
       """
+
+  Scenario: Load file and name test file
+    When I create a test file called "foo-init.el" with content:
+      """
+      (defun foo ())
+      """
+    When I create a test file called "foo-test.el" with content:
+      """
+      (ert-deftest foo-test () (foo))
+      """
+    When I create a test file called "bar-test.el" with content:
+      """
+      (ert-deftest bar-test () (error "BOOM"))
+      """
+    When I run cask exec "{ERT-RUNNER} --load test/foo-init.el test/foo.el"
+    Then I should see output:
+      """
+         passed  1/1  foo-test
+      """
+    Then I should not see error "BOOM"
 
   Scenario: Load path
     When I create a test file called "foo-init.el" with content:


### PR DESCRIPTION
Commands that accept file lists at the end should not have unterminated
argument parameters.