### PR TITLE
Pre-populate test/test-helper.el and test/NAME-test.el

### DIFF
--- a/ert-runner.el
+++ b/ert-runner.el
@@ -210,12 +210,23 @@ nil, `ert-runner-test-path' will be used instead."
   (unless name (setq name (f-filename default-directory)))
   (if (f-dir? "test")
       (error (ansi-red "Directory `test` already exists.")))
-  (f-mkdir ert-runner-test-path)
-  (f-touch (f-join ert-runner-test-path "test-helper.el"))
-  (f-touch (f-join ert-runner-test-path (s-concat name "-test.el")))
   (message "create %s" (ansi-green (f-filename ert-runner-test-path)))
+  (f-mkdir ert-runner-test-path)
   (message "create  %s" (ansi-green "test-helper.el"))
-  (message "create  %s" (ansi-green (s-concat name "-test.el"))))
+  (let ((test-file (s-concat name "-test.el")))
+    (with-temp-file (f-join ert-runner-test-path "test-helper.el")
+      (insert (format "\
+;;; test-helper.el --- Helpers for %s
+
+;;; test-helper.el ends here
+" test-file)))
+    (message "create  %s" (ansi-green (s-concat name "-test.el")))
+    (with-temp-file (f-join ert-runner-test-path test-file)
+      (insert (format "\
+;;; %s --- Tests for %s
+
+;;; %s ends here
+" test-file name test-file)))))
 
 (defun ert-runner/debug ()
   "Enable debug."


### PR DESCRIPTION
This follows #38, in particular https://github.com/rejeep/ert-runner.el/issues/38#issuecomment-282552310 ff.

I am only adding basic header and footer lines. It might however be a good idea to insert some templates in between to make it easier for users to get started. I'll leave that to you because I don't know what conventions you would prefer users to follow here. If you do that, then feel free to attribute the amended/new commit to yourself instead of to me.

We could also add a comment like `;; This isn't a library, so no feature should be provided`, to make it even more likely that users won't do that. But that seems like a bit much.