### PR TITLE
Guard against getenv returning nil

### DIFF
--- a/ert-runner.el
+++ b/ert-runner.el
@@ -346,7 +346,8 @@ nil, `ert-runner-test-path' will be used instead."
           (run-hook-with-args 'ert-runner-reporter-test-ended-functions
                               stats test result)))))))
 
-(setq commander-args (-reject 's-blank? (s-split " " (getenv "ERT_RUNNER_ARGS"))))
+(-when-let (args (getenv "ERT_RUNNER_ARGS"))
+  (setq commander-args (-reject 's-blank? (s-split " " args))))
 
 (commander
  (name "ert-runner")


### PR DESCRIPTION
`getenv` can return `nil` if the env variable is undefined (previously probably returned empty string?)  This breaks loading the package when the envvar is not defined.