### PR TITLE
profiler off by default, use --profile to enable

### DIFF
--- a/ert-runner.el
+++ b/ert-runner.el
@@ -62,7 +62,7 @@
 (defvar ert-runner-verbose t
   "If true, show all message output, otherwise hide.")
 
-(defvar ert-runner-profile t
+(defvar ert-runner-profile nil
   "If true, show profiling output, otherwise hide.")
 
 (defvar ert-runner-output-buffer "*ert-runner outout*"


### PR DESCRIPTION
it looks like https://github.com/rejeep/ert-runner.el/pull/55 accidentally enabled profiling by default, when it should be enabled only when `--profile` is used.
