### PR TITLE
fix(profiler): set correct variable

### DIFF
--- a/ert-runner.el
+++ b/ert-runner.el
@@ -245,7 +245,7 @@ nil, `ert-runner-test-path' will be used instead."
 
 (defun ert-runner/profile ()
   "Show profiling output."
-  (setq ert-runner-profiler t))
+  (setq ert-runner-profile t))
 
 (defun ert-runner/quiet ()
   "Do not show package output."


### PR DESCRIPTION
Calling `ert-runner/profile` (by passing option `--profile`) would set undeclared variable `ert-runner-profiler` instead of `ert-runner-profile` with only the latter being consumed during `ert-runner/run-tests-batch-and-exit`.